### PR TITLE
no fatal error on modified baseq3a

### DIFF
--- a/code/qcommon/files.c
+++ b/code/qcommon/files.c
@@ -4837,7 +4837,6 @@ static void FS_CheckIdPaks( void )
 						"**************************************************\n\n\n",
 						pakBasename[3]-'0', path->pack->checksum );
 				}
-				Com_Error(ERR_FATAL, "\n* You need to install correct Quake III Arena files in order to play *");
 			}
 
 			foundPak |= 1<<(pakBasename[3]-'0');


### PR DESCRIPTION
this will still warn the player about altered pak0-pak8 files but still allows to play. this allows the player to repack/alter the baseq3 content