### PR TITLE
Fix VM_Call crash in DLL mode when nargs is 0

### DIFF
--- a/code/qcommon/vm.c
+++ b/code/qcommon/vm.c
@@ -1960,6 +1960,7 @@ intptr_t QDECL VM_Call( vm_t *vm, int nargs, int callnum, ... )
 		//rcg010207 -  see dissertation at top of VM_DllSyscall() in this file.
 		int32_t args[MAX_VMMAIN_CALL_ARGS-1];
 		va_list ap;
+		memset( args, 0, sizeof( args ) );
 		va_start( ap, callnum );
 		for ( i = 0; i < nargs; i++ ) {
 			args[i] = va_arg( ap, int32_t );


### PR DESCRIPTION
## Summary

Fixes a crash (SIGBUS) on ARM64 when using native DLL cgame modules (e.g. [cgame-proxymod](https://github.com/Jelvan1/cgame-proxymod)).

On ARM64 with `-O2`, the compiler transforms the `for` loop in `VM_Call`'s DLL path into a do-while loop without a zero-trip guard. When `nargs` is 0 (used by `CG_CONSOLE_COMMAND` and `CG_SHUTDOWN`), the va_arg copy loop never terminates and reads past the stack into the guard page, causing a SIGBUS crash.

The VM interpreter path already handles this correctly — the compiled code includes a `cmp w1, #1; b.lt skip` guard before its copy loop.

### Fix

Zero-initialize the `args` array with `memset`. This gives the compiler a separate initialization path that prevents it from eliminating the loop guard during optimization.

### Reproduction

1. Build for macOS ARM64 (Apple Silicon)
2. Load a native cgame DLL (e.g. cgame-proxymod with `vm_cgame 0`)
3. Enter a map and trigger any console command routed to cgame (e.g. weapon switch)
4. Engine crashes with `Received signal 10` (SIGBUS)

See also: https://github.com/Jelvan1/cgame-proxymod/issues/14